### PR TITLE
Fix exception when LDAP user is like "1234"

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -294,6 +294,9 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		if (is_string($user)) {
 			$user = $this->access->userManager->get($user);
 		}
+		elseif (is_numeric($user)) {
+			$user = $this->access->userManager->get($user);
+		}
 		if (is_null($user)) {
 			return false;
 		}


### PR DESCRIPTION
Fix the userExistsOnLDAP($user) function, because PHP crashes if the LDAP user name is a numeric string like "1234"